### PR TITLE
Added image directory variables and option to view images inline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ where the markdown file you are inserting into is named
 A new folder will be created for each markdown file you insert
 into.
 
+To change the image save location, please see the settings below.
+
 You can drag and drop images from a web browser as well and the
 program will try and download the image and put it in the local
 folder.
+
+Please note that on Linux images cannot be dragged from the Chrome browser.
 
 Technically, it doesn't have to be inserted into a buffer currently
 in markdown-mode, but it is going to insert the markdown image tag
@@ -31,6 +35,24 @@ Place this file `markdown-dnd-images.el` somewhere in your load
 path and put this (or something similiar) in your .emacs file.
 
     (require 'markdown-dnd-images)
+    
+    ## Settings ##
+
+    To save images in a directory other than ~/.emacs.d/markdown-image-files... The save directory may be relative to the buffer file (ex. images) or absolute (ex. ~/image_directory_all_files).
+
+        (setq dnd-save-directory "images")
+
+    By default, images are saved inside subfolder of the image directory that's unique to the buffer. The subfolder's named "images_for_buffername.file_ext". To save images without the subfolder:
+
+        (setq dnd-save-buffer-name nil)
+        
+    Viewing saved images inline requires markdown-mode. To view images inline as they are dragged to the file:
+
+        (setq dnd-view-inline t)
+        
+    To save the image's original url and access date:
+        
+        (setq dnd-capture-source t)
 
 ## Notes ##
 
@@ -38,5 +60,5 @@ Spaces in file names will be replaced with underscores.
 
 ## TODO ##
 
-Curretnly, this will supercede the normal drag and drop behavior in
+Currently, this will supercede the normal drag and drop behavior in
 all buffers. TODO: only for certain buffers?


### PR DESCRIPTION
With markdown-mode's new max-width feature for inline images, this came pretty close to perfect.

I added the following settings:

- On image download inline view (markdown mode dependency only if set to true)
- Setting to change the save directory, if needed.
- Optional setting for buffer specific subfolders. (In my case, I use this on a project level. Since my save directory setting is relative to the buffer, I didn't need the subfolder.)
- Option to capture the original image url and access date. 